### PR TITLE
Tester: add errorDescription to error message

### DIFF
--- a/src/ArcepApiBoxTester/Controller/Tester.php
+++ b/src/ArcepApiBoxTester/Controller/Tester.php
@@ -215,7 +215,7 @@ class Tester {
             $this->_jsonResponse($accessToken);
         } catch (Exception $e) {
             // Failed to get the access token
-            $this->Error = 'OAuth2 Client initialization error: '.$e->getMessage();
+            $this->Error = 'OAuth2 Client initialization error: '.$e->getMessage(). ' : '.$e->getResponseBody()['errorDescription'];
             $this->_jsonResponse([]);
         }
     }


### PR DESCRIPTION
I needed to have more information during debugging, added the content of the error description. Not sure it's the best way to do this, or what happens when description is not set.