### PR TITLE
OAuthProvider: allow setting a client TLS key and certificate

### DIFF
--- a/src/ArcepApiBoxTester/Model/OAuthProvider.php
+++ b/src/ArcepApiBoxTester/Model/OAuthProvider.php
@@ -231,4 +231,12 @@ class OAuthProvider extends AbstractProvider {
 
         return $token;
     }
+    protected function getAllowedClientOptions(array $options)
+    {
+        $client_options = ['cert', 'ssl_key'];
+
+        $parent_options = parent::getAllowedClientOptions($options);
+
+        return array_merge($parent_options, $client_options);
+    }
 }


### PR DESCRIPTION
This allows using the two "cert" and "ssl_key" options in an ISP config,
like this:

        "Free": {
            "urlAccessToken": "https://XXXX-api-domain-tls-mutual",
            "urlPrec": "{SCOPE}/tca/prec",
            "urlPostc": "{SCOPE}/tca/postc?unique_id={UNIQUE_ID}",
            "authLogin": "XXX",
            "authPassword": "XXX",
            "ipStack": "ipv6Preferred"
            "ssl_key": "free.client.key.pem",
            "cert": "free.client.cert.pem"
        }
